### PR TITLE
Rename accesor -> accessor to fix typo

### DIFF
--- a/src/Accessor.php
+++ b/src/Accessor.php
@@ -3,10 +3,10 @@
 namespace Underscore;
 
 /**
- * Class Accesor
+ * Class Accessor
  * @package Underscore
  */
-abstract class Accesor
+abstract class Accessor
 {
 
 }

--- a/src/Accessor/SizeAccessor.php
+++ b/src/Accessor/SizeAccessor.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Underscore\Accesor;
+namespace Underscore\Accessor;
 
-use Underscore\Accesor;
+use Underscore\Accessor;
 use Underscore\Collection;
 
 /**
- * Class SizeAccesor
- * @package Underscore\Accesor
+ * Class SizeAccessor
+ * @package Underscore\Accessor
  */
-class SizeAccesor extends Accesor
+class SizeAccessor extends Accessor
 {
     /**
      * Gets the size of the collection by returning length for arrays or number of enumerable properties for objects.

--- a/src/Accessor/ToArrayAccessor.php
+++ b/src/Accessor/ToArrayAccessor.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Underscore\Accesor;
+namespace Underscore\Accessor;
 
-use Underscore\Accesor;
+use Underscore\Accessor;
 use Underscore\Collection;
 
 /**
- * Class ToArrayAccesor
- * @package Underscore\Accesor
+ * Class ToArrayAccessor
+ * @package Underscore\Accessor
  */
-class ToArrayAccesor extends Accesor
+class ToArrayAccessor extends Accessor
 {
     /**
      * Returns wrapped object as an array

--- a/src/Accessor/ValueAccessor.php
+++ b/src/Accessor/ValueAccessor.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Underscore\Accesor;
+namespace Underscore\Accessor;
 
-use Underscore\Accesor;
+use Underscore\Accessor;
 use Underscore\Collection;
 
 /**
- * Class ValueAccesor
- * @package Underscore\Accesor
+ * Class ValueAccessor
+ * @package Underscore\Accessor
  */
-class ValueAccesor extends Accesor
+class ValueAccessor extends Accessor
 {
     /**
      * Returns wrapped object

--- a/src/Underscore.php
+++ b/src/Underscore.php
@@ -63,7 +63,7 @@ class Underscore
     {
         $payloadClass = sprintf('\Underscore\Mutator\%sMutator', ucfirst($method));
         if (!class_exists($payloadClass)) {
-            $payloadClass = sprintf('\Underscore\Accesor\%sAccesor', ucfirst($method));
+            $payloadClass = sprintf('\Underscore\Accessor\%sAccessor', ucfirst($method));
         }
 
         if (!class_exists($payloadClass)) {
@@ -91,7 +91,7 @@ class Underscore
     }
 
     /**
-     * Payload is either Mutator or Accesor. Both are supposed to be callable.
+     * Payload is either Mutator or Accessor. Both are supposed to be callable.
      *
      * @param callable $payload
      * @param array    $args


### PR DESCRIPTION
http://cplus.about.com/od/glossar1/g/accessor.htm

Spelling with a single "s" would be correct for Latin languages, but not English.