### PR TITLE
Drop PHP 5.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-    - 5.6
-    - 5.5
     - 5.4
-    - 5.3
+    - 5.5
+    - 5.6
+    - 7.0
     - hhvm
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require":  {
-        "php": ">=5.3.0"
+        "php": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7"


### PR DESCRIPTION
PHP 5.3 has been unsupported since 2014-08-14, there is no reason to continue supporting it.

Also adds testing for PHP 7.0 for future proofing. :)