### PR TITLE
Create a class registry for callable aliases

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,9 @@
         <filter>
             <whitelist>
                 <directory>./lib/Underscore/</directory>
+                <exclude>
+                    <directory>./tests/Underscore/Test/Fixture</directory>
+                </exclude>
             </whitelist>
         </filter>
 

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Underscore;
+
+/**
+ * Callable registry for Underscore methods.
+ *
+ * It is assumed that all callables will be classes with an `__invoke` method.
+ *
+ * Existing methods can be overloaded by setting an alias of the same name:
+ *
+ *     $registry->alias('keys', 'Acme\KeysMutator');
+ *
+ * New methods can be added in the same way:
+ *
+ *     $registry->alias('fancy', 'Acme\FancyInitializer');
+ *
+ * Every alias is a singleton and will only be created once! If your callable
+ * requires construction, alias a fully constructed object instead:
+ *
+ *     $registry->alias('fancy', new FancyInitializer($parameters));
+ *
+ * NOTE: Mutators, accessors, and initializers all use the same registery and
+ * differ only in how they are used internally by Underscore.
+ */
+class Registry
+{
+    /**
+     * @var array Classes aliased by name of method.
+     */
+    private $aliases = [];
+
+    /**
+     * @var array Callable instances aliased by name of method.
+     */
+    private $instances = [];
+
+    /**
+     * @param array $aliases
+     */
+    public function __construct(array $aliases = [])
+    {
+        $this->aliases = $aliases;
+    }
+
+    /**
+     * Get the callable for an Underscore method alias.
+     *
+     * @param  string $name
+     * @return callable
+     */
+    public function instance($name)
+    {
+        if (empty($this->instances[$name])) {
+            if (empty($this->aliases[$name])) {
+                $this->aliasDefault($name);
+            }
+            $this->instances[$name] = new $this->aliases[$name];
+        }
+
+        return $this->instances[$name];
+    }
+
+    /**
+     * Alias method name to a callable.
+     *
+     * @param  string $name
+     * @param  callable $spec
+     * @return void
+     */
+    public function alias($name, $spec)
+    {
+        if (is_callable($spec)) {
+            $this->instances[$name] = $spec;
+        } else {
+            $this->aliases[$name] = $spec;
+
+            // Ensure that the new alias will be used when called.
+            unset($this->instances[$name]);
+        }
+    }
+
+    /**
+     * Define a default mutator, accessor, or initializer for a method name.
+     *
+     * @throws BadMethodCallException If no default can be located.
+     * @param  string $name
+     * @return void
+     */
+    private function aliasDefault($name)
+    {
+        $spec = sprintf('\Underscore\Mutator\%sMutator', ucfirst($name));
+
+        if (!class_exists($spec)) {
+            $spec = sprintf('\Underscore\Accessor\%sAccessor', ucfirst($name));
+        }
+
+        if (!class_exists($spec)) {
+            $spec = sprintf('\Underscore\Initializer\%sInitializer', ucfirst($name));
+        }
+
+        if (!class_exists($spec)) {
+            throw new \BadMethodCallException(sprintf('Unknown method Underscore->%s()', $name));
+        }
+
+        $this->aliases[$name] = $spec;
+    }
+}

--- a/src/Underscore.php
+++ b/src/Underscore.php
@@ -43,6 +43,35 @@ namespace Underscore;
  */
 class Underscore
 {
+    /** @var Registry */
+    protected static $registry;
+
+    /**
+     * Set the registry singleton.
+     *
+     * @param  Registry $registry
+     * @return void
+     */
+    public static function setRegistry(Registry $registry)
+    {
+        static::$registry = $registry;
+    }
+
+    /**
+     * Get the registry singleton.
+     *
+     * Creates a new registry if none exists.
+     *
+     * @return Registry
+     */
+    public static function getRegistry()
+    {
+        if (!static::$registry) {
+            static::$registry = new Registry;
+        }
+        return static::$registry;
+    }
+
     /** @var  Collection */
     protected $wrapped;
 
@@ -62,17 +91,8 @@ class Underscore
      */
     public function __call($method, $args)
     {
-        $payloadClass = sprintf('\Underscore\Mutator\%sMutator', ucfirst($method));
-        if (!class_exists($payloadClass)) {
-            $payloadClass = sprintf('\Underscore\Accessor\%sAccessor', ucfirst($method));
-        }
-
-        if (!class_exists($payloadClass)) {
-            throw new \BadMethodCallException("Unknown method Underscore->{$method}()");
-        }
-
         /** @var $payload callable */
-        $payload = new $payloadClass();
+        $payload = static::getRegistry()->instance($method);
 
         return $this->executePayload($payload, $args);
     }
@@ -84,9 +104,8 @@ class Underscore
      */
     public static function __callStatic($method, $args)
     {
-        $payloadClass = sprintf('\Underscore\Initializer\%sInitializer', ucfirst($method));
         /** @var $payload callable */
-        $payload = new $payloadClass();
+        $payload = static::getRegistry()->instance($method);
 
         return call_user_func_array($payload, $args);
     }

--- a/tests/Underscore/Test/Fixture/Mutator/ChefMutator.php
+++ b/tests/Underscore/Test/Fixture/Mutator/ChefMutator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Underscore\Test\Fixture\Mutator;
+
+use Underscore\Mutator;
+
+/**
+ * @codeCoverageIgnore
+ */
+class ChefMutator extends Mutator
+{
+    public function __invoke($collection)
+    {
+        $collection = clone $collection;
+        $collection['chef'] = 'Bork! Bork! Bork!';
+        return $collection;
+    }
+}

--- a/tests/Underscore/Test/RegistryTest.php
+++ b/tests/Underscore/Test/RegistryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Underscore\Test;
+
+use Underscore\Registry;
+
+class RegistryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefault()
+    {
+        $registry = new Registry();
+
+        $this->assertInstanceOf('Underscore\Accessor\ValueAccessor', $registry->instance('value'));
+        $this->assertInstanceOf('Underscore\Initializer\FromInitializer', $registry->instance('from'));
+        $this->assertInstanceOf('Underscore\Mutator\LastMutator', $registry->instance('last'));
+    }
+
+    public function testConstructorAlias()
+    {
+        $registry = new Registry([
+            'last' => 'Underscore\Test\Fixture\Mutator\ChefMutator',
+        ]);
+
+        $this->assertInstanceOf('Underscore\Test\Fixture\Mutator\ChefMutator', $registry->instance('last'));
+    }
+
+    public function testAliasSpec()
+    {
+        $registry = new Registry();
+
+        $this->assertInstanceOf('Underscore\Mutator\LastMutator', $registry->instance('last'));
+
+        $registry->alias('last', 'Underscore\Test\Fixture\Mutator\ChefMutator');
+
+        $this->assertInstanceOf('Underscore\Test\Fixture\Mutator\ChefMutator', $registry->instance('last'));
+    }
+
+    public function testAliasConcrete()
+    {
+        $registry = new Registry();
+
+        $accessor = function ($collection) {};
+
+        $registry->alias('fin', $accessor);
+
+        $this->assertSame($accessor, $registry->instance('fin'));
+    }
+
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testMissingInstance()
+    {
+        $registry = new Registry();
+
+        $registry->instance('invalid');
+    }
+}

--- a/tests/Underscore/Test/UnderscoreTest.php
+++ b/tests/Underscore/Test/UnderscoreTest.php
@@ -41,6 +41,23 @@ abstract class UnderscoreTest extends \PHPUnit_Framework_TestCase
         return $out;
     }
 
+    public function testRegistry()
+    {
+        // Get current registry
+        $registry = Underscore::getRegistry();
+
+        $this->assertInstanceOf('Underscore\Registry', $registry);
+
+        $mocked = $this->getMockBuilder('Underscore\Registry')->getMock();
+
+        Underscore::setRegistry($mocked);
+
+        $this->assertSame($mocked, Underscore::getRegistry());
+
+        // Restore original registry
+        Underscore::setRegistry($registry);
+    }
+
     /**
      * @dataProvider getTestRangeData
      */


### PR DESCRIPTION
Rather than creating new instances of callable classes on every invocation, switch to a central alias/instance registry.

Discovers default aliases for mutators, accessors, and initializers while also allowing new method aliases to be added or existing aliases to be overloaded.

Refs #25
Fixes #41